### PR TITLE
1.13-1.19插件可用

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: BoatFly-BootLoader
 version: '${project.version}'
 main: com.wenkrang.boatflybootloader.BoatFly_BootLoader
-api-version: '1.20'
+api-version: '1.13'
 commands:
   bl:
     description: Spigot版本的飞船插件加载器的主命令


### PR DESCRIPTION
BootLoader的APIVersion被设置为1.20，导致1.19.4及以下版本（理论上可用）无法正常加载：
``` Console
[06:37:46 ERROR]: Could not load 'plugins\BoatFly-BootLoader-1.5.5c.jar' in folder 'plugins'
org.bukkit.plugin.InvalidPluginException: Unsupported API version 1.20
        at org.bukkit.craftbukkit.v1_19_R2.util.CraftMagicNumbers.checkSupported(CraftMagicNumbers.java:380) ~[leaf-1.19.3.jar:git-Leaf-"4ac45c3"]
        at org.bukkit.plugin.java.JavaPluginLoader.loadPlugin(JavaPluginLoader.java:150) ~[leaf-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.loadPlugin(SimplePluginManager.java:413) ~[leaf-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.SimplePluginManager.loadPlugins(SimplePluginManager.java:321) ~[leaf-api-1.19.3-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.v1_19_R2.CraftServer.loadPlugins(CraftServer.java:443) ~[leaf-1.19.3.jar:git-Leaf-"4ac45c3"]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:301) ~[leaf-1.19.3.jar:git-Leaf-"4ac45c3"]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1217) ~[leaf-1.19.3.jar:git-Leaf-"4ac45c3"]
        at net.minecraft.server.MinecraftServer.lambda$spin$1(MinecraftServer.java:416) ~[leaf-1.19.3.jar:git-Leaf-"4ac45c3"]
        at java.lang.Thread.run(Thread.java:840) ~[?:?]
```